### PR TITLE
Update log file permissions

### DIFF
--- a/modules/log/file.go
+++ b/modules/log/file.go
@@ -137,7 +137,7 @@ func (log *FileLogger) docheck(size int) {
 
 func (log *FileLogger) createLogFile() (*os.File, error) {
 	// Open the log file
-	return os.OpenFile(log.Filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o660)
+	return os.OpenFile(log.Filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o664)
 }
 
 func (log *FileLogger) initFd() error {


### PR DESCRIPTION
I have external software that reads the Gitea log files and sends them to another server. The issue is that the logs aren't readable by the monitoring process.

This PR makes log files globally readable when created/rotated.
